### PR TITLE
Fix link to CSSclasses

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,7 +55,7 @@ sections:
         desc: "A first foray into learning the languages of the web: 
               HTML and CSS."
       - title: CSSclasses
-        url: http://cssclasses.cssconf.eu/learning-materials/
+        url: http://cssclasses.cssconf.eu/materials/
         source: https://github.com/OpenTechSchool/CSSclasses/
         code: false
         desc: "Learn CSS in a playful way and experiment in the browser."


### PR DESCRIPTION
Got a 404 when coming from the homepage. The nav entry "Learning materials" on the CSSclasses site points to the updated link.